### PR TITLE
Warn instead of panic on missing window

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -17,7 +17,10 @@ pub(crate) fn init_camera(
     mut images: ResMut<Assets<Image>>,
     mut commands: Commands,
 ) {
-    let window = window_query.single();
+    let Ok(window) = window_query.get_single() else {
+        warn!("No window found, can't run init_camera");
+        return;
+    };
 
     for (
         PixelCamera {


### PR DESCRIPTION
Closes #4. I think a warning is nicer instead of a panic here.