### PR TITLE
Add support for Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_sprite",
 ] }
 
 [dev-dependencies]
-bevy = "0.13.0"
+bevy = "0.14.0"
 
 [lints]
 rust.missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_sprite",
 ] }
 
 [dev-dependencies]
-bevy = "0.14.0"
+bevy = "0.15.0"
 
 [lints]
 rust.missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_sprite",
 ] }
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+bevy = "0.13.0"
 
 [lints]
 rust.missing_docs = "warn"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,6 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // turn it into a smooth pixel perfect camera.
     commands.spawn((
         Camera2d,
+        Msaa::Off,
         PixelCamera::from_size(ViewportSize::PixelFixed(32)),
     ));
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,23 +25,19 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn a 2d camera with the PixelCamera bundle in order to
     // turn it into a smooth pixel perfect camera.
     commands.spawn((
-        Camera2dBundle::default(),
+        Camera2d,
         PixelCamera::from_size(ViewportSize::PixelFixed(32)),
     ));
 
     // Spawn a checkerboard background
-    commands.spawn(SpriteBundle {
-        texture: asset_server.load("checkerboard.png"),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
-        ..default()
-    });
+    commands.spawn((
+        Sprite::from_image(asset_server.load("checkerboard.png")),
+        Transform::from_xyz(0.0, 0.0, 0.0),
+    ));
     // Spawn a bevy icon sprite and mark it with the `BevyIcon` component
     commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("bevy_pixel_dark.png"),
-            transform: Transform::from_xyz(0.0, 0.0, 1.0),
-            ..default()
-        },
+        Sprite::from_image(asset_server.load("bevy_pixel_dark.png")),
+        Transform::from_xyz(0.0, 0.0, 1.0),
         BevyIcon,
     ));
 }
@@ -54,10 +50,10 @@ fn update(
     // Get the camera and move it horizontally over time
     let mut camera = camera.single_mut();
 
-    camera.subpixel_pos.x = (time.elapsed_seconds() / 2.0).sin() * 10.0;
+    camera.subpixel_pos.x = (time.elapsed_secs() / 2.0).sin() * 10.0;
 
     // Get the bevy icon and move it vertically over time
     let mut bevy_transform = bevy.single_mut();
 
-    bevy_transform.translation.y = time.elapsed_seconds().sin() * 4.5;
+    bevy_transform.translation.y = time.elapsed_secs().sin() * 4.5;
 }

--- a/examples/basic_no_smoothing.rs
+++ b/examples/basic_no_smoothing.rs
@@ -27,7 +27,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn a 2d camera with the PixelCamera bundle in order to
     // turn it into a smooth pixel perfect camera.
     commands.spawn((
-        Camera2dBundle::default(),
+        Camera2d,
         PixelCamera {
             viewport_size: ViewportSize::PixelFixed(32),
             smoothing: false,
@@ -36,18 +36,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 
     // Spawn a checkerboard background
-    commands.spawn(SpriteBundle {
-        texture: asset_server.load("checkerboard.png"),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
-        ..default()
-    });
+    commands.spawn((
+        Sprite::from_image(asset_server.load("checkerboard.png")),
+        Transform::from_xyz(0.0, 0.0, 0.0),
+    ));
     // Spawn a bevy icon sprite and mark it with the `BevyIcon` component
     commands.spawn((
-        SpriteBundle {
-            texture: asset_server.load("bevy_pixel_dark.png"),
-            transform: Transform::from_xyz(0.0, 0.0, 1.0),
-            ..default()
-        },
+        Sprite::from_image(asset_server.load("bevy_pixel_dark.png")),
+        Transform::from_xyz(0.0, 0.0, 1.0),
         BevyIcon,
     ));
 }
@@ -60,10 +56,10 @@ fn update(
     // Get the camera and move it horizontally over time
     let mut camera = camera.single_mut();
 
-    camera.subpixel_pos.x = (time.elapsed_seconds() / 2.0).sin() * 10.0;
+    camera.subpixel_pos.x = (time.elapsed_secs() / 2.0).sin() * 10.0;
 
     // Get the bevy icon and move it vertically over time
     let mut bevy_transform = bevy.single_mut();
 
-    bevy_transform.translation.y = time.elapsed_seconds().sin() * 4.5;
+    bevy_transform.translation.y = time.elapsed_secs().sin() * 4.5;
 }

--- a/examples/basic_no_smoothing.rs
+++ b/examples/basic_no_smoothing.rs
@@ -28,6 +28,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // turn it into a smooth pixel perfect camera.
     commands.spawn((
         Camera2d,
+        Msaa::Off,
         PixelCamera {
             viewport_size: ViewportSize::PixelFixed(32),
             smoothing: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ impl Plugin for PixelCameraPlugin {
     fn build(&self, app: &mut App) {
         use systems::*;
 
-        app.insert_resource(Msaa::Off).add_systems(
+        app.add_systems(
             PostUpdate,
             (
                 init_camera.in_set(CameraSystems::Initialization),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -82,11 +82,8 @@ pub(crate) fn init_camera(
 
         let viewport_sprite = commands
             .spawn((
-                SpriteBundle {
-                    texture: image_handle,
-                    transform: Transform::from_scale(Vec3::splat(1.0)),
-                    ..default()
-                },
+                Sprite::from_image(image_handle),
+                Transform::from_scale(Vec3::splat(1.0)),
                 viewport_layer.clone(),
                 PixelViewport,
             ))
@@ -94,23 +91,20 @@ pub(crate) fn init_camera(
 
         let viewport_camera = commands
             .spawn((
-                Camera2dBundle {
-                    camera: Camera {
-                        order: *viewport_order,
-                        clear_color: viewport_size.clear_color(),
-                        ..default()
-                    },
-                    projection: OrthographicProjection {
-                        far: 1000.,
-                        near: -1000.,
-                        scaling_mode: ScalingMode::Fixed {
-                            width: (size.width - 2) as f32,
-                            height: (size.height - 2) as f32,
-                        },
-                        ..default()
-                    },
-
+                Camera2d,
+                Camera {
+                    order: *viewport_order,
+                    clear_color: viewport_size.clear_color(),
                     ..default()
+                },
+                OrthographicProjection {
+                    far: 1000.,
+                    near: -1000.,
+                    scaling_mode: ScalingMode::Fixed {
+                        width: (size.width - 2) as f32,
+                        height: (size.height - 2) as f32,
+                    },
+                    ..OrthographicProjection::default_2d()
                 },
                 ViewportCamera,
                 viewport_layer.clone(),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -87,7 +87,7 @@ pub(crate) fn init_camera(
                     transform: Transform::from_scale(Vec3::splat(1.0)),
                     ..default()
                 },
-                *viewport_layer,
+                viewport_layer.clone(),
                 PixelViewport,
             ))
             .id();
@@ -113,7 +113,7 @@ pub(crate) fn init_camera(
                     ..default()
                 },
                 ViewportCamera,
-                *viewport_layer,
+                viewport_layer.clone(),
             ))
             .id();
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -268,7 +268,7 @@ pub(crate) fn set_camera_position(mut cameras: Query<(&PixelCamera, &mut Transfo
 pub(crate) fn smooth_camera(
     mut cameras: Query<(&PixelCamera, &PixelViewportReferences)>,
     mut viewports: Query<
-        (&mut Sprite, &Handle<Image>),
+        &mut Sprite,
         (With<PixelViewport>, Without<PixelViewportReferences>),
     >,
     images: Res<Assets<Image>>,
@@ -285,8 +285,8 @@ pub(crate) fn smooth_camera(
         if !smoothing {
             continue;
         }
-        let (mut sprite, handle) = viewports.get_mut(viewport.sprite).unwrap();
-        let Some(image) = images.get(handle) else {
+        let mut sprite = viewports.get_mut(viewport.sprite).unwrap();
+        let Some(image) = images.get(&sprite.image) else {
             error!(
                 "Pixel camera viewport ({:?}) image doesn't exist",
                 viewport.sprite


### PR DESCRIPTION
This patch adds support for Bevy 0.15, by following the upgrade guides. One change that might require some extra scrutiny is https://github.com/doonv/bevy_smooth_pixel_camera/commit/64453fddbab8a7c3b012c9b7106dd05e63927d38, which removes adding `Masa::Off`, which is no longer a resource in Bevy 0.15. Instead, it's added to the examples.